### PR TITLE
Linux dev installation (zsh and conda environment + `clang` dependency)

### DIFF
--- a/_includes/install/commons/dev/link_conda_codebase.md
+++ b/_includes/install/commons/dev/link_conda_codebase.md
@@ -9,10 +9,10 @@ cat <<EOF >${CONDA_PREFIX}/etc/conda/activate.d/anvio.sh
 # (2) the shell knows where to find anvi'o programs, and (3) every time
 # the environment is activated it synchronizes with the latest code from
 # active GitHub repository:
-export PYTHONPATH=\$PYTHONPATH:~/github/anvio/
-export PATH=\$PATH:~/github/anvio/bin:~/github/anvio/sandbox
+export PYTHONPATH=\$PYTHONPATH:\$HOME/github/anvio/
+export PATH=\$PATH:\$HOME/github/anvio/bin:\$HOME/github/anvio/sandbox
 echo -e "\033[1;34mUpdating from anvi'o GitHub \033[0;31m(press CTRL+C to cancel)\033[0m ..."
-cd ~/github/anvio && git pull && cd -
+cd \$HOME/github/anvio && git pull && cd -
 EOF
 ```
 

--- a/install/linux/dev.md
+++ b/install/linux/dev.md
@@ -35,7 +35,7 @@ This page is for users who want to install the development version of anvi'o, `a
 {% include install/commons/dev/python_dependencies.md %}
 
 {:.warning}
-You might see errors during the pip installation that include a line like `Building wheel for XXXXXX did not run successfully.` and also a line like `error: command 'gcc' failed: No such file or directory`. If this is the case, the problem is that your Linux installation does not include the GCC compiler. You can fix that by running the following commands to upgrade your system and install the compiler: `sudo apt update`, followed by `sudo apt full-upgrade`, and finally `sudo apt install gcc`. Once those are complete, please retry the `pip install` command.
+You might see errors during the pip installation that include a line like `Building wheel for XXXXXX did not run successfully.` and also a line like `error: command 'gcc' failed: No such file or directory`. If this is the case, the problem is that your Linux installation does not include the GCC compiler. You can fix that by running the following commands to upgrade your system and install the compiler: `sudo apt update`, followed by `sudo apt full-upgrade`, and finally `sudo apt install gcc clang`. Once those are complete, please retry the `pip install` command.
 
 {% include install/commons/dev/python_dependencies_conclusion.md %}
 


### PR DESCRIPTION
Hello!

This PR addresses a minor issue in `${CONDA_PREFIX}/etc/conda/activate.d/anvio.sh` (mentioned at https://anvio.org/install/linux/dev/) that affected compatibility with both `zsh` and `bash`. The problem was likely due to improper expansion of the `~` character. By replacing it with the (properly escaped) `$HOME` variable (which is POSIX-compliant) the script should now work correctly in any shell.  

I have tested these changes with `zsh`, and everything works OK for me.  
If this fix works for you, the red banner with `exec bash` and `exec zsh` can be removed in a future update.  

Additionally, I encountered an issue during the installation of `datrie` because `clang` was missing.  
Since `clang` is mentioned in the exports (see screenshot below), it may be worth adding it to the installation instructions.
<img src="https://github.com/user-attachments/assets/07c461a2-fa0e-44ce-abc1-479ee42f6296" alt="clang exports" width="350">

With kind regards,
Vladimir